### PR TITLE
add validation to prevent passing non-numerical data to corr_mat

### DIFF
--- a/src/klib/describe.py
+++ b/src/klib/describe.py
@@ -15,18 +15,17 @@ import numpy as np
 import pandas as pd
 import scipy
 import seaborn as sns
-from matplotlib import ticker
-from matplotlib.colors import LinearSegmentedColormap
-from matplotlib.colors import to_rgb
-
 from klib.utils import _corr_selector
 from klib.utils import _missing_vals
 from klib.utils import _validate_input_bool
 from klib.utils import _validate_input_int
+from klib.utils import _validate_input_num_data
 from klib.utils import _validate_input_range
 from klib.utils import _validate_input_smaller
 from klib.utils import _validate_input_sum_larger
-from klib.utils import _validate_input_num_data
+from matplotlib import ticker
+from matplotlib.colors import LinearSegmentedColormap
+from matplotlib.colors import to_rgb
 
 __all__ = ["cat_plot", "corr_mat", "corr_plot", "dist_plot", "missingval_plot"]
 

--- a/src/klib/describe.py
+++ b/src/klib/describe.py
@@ -26,6 +26,7 @@ from klib.utils import _validate_input_int
 from klib.utils import _validate_input_range
 from klib.utils import _validate_input_smaller
 from klib.utils import _validate_input_sum_larger
+from klib.utils import _validate_input_num_data
 
 __all__ = ["cat_plot", "corr_mat", "corr_plot", "dist_plot", "missingval_plot"]
 
@@ -223,6 +224,8 @@ def corr_mat(
         return f"color: {color}"
 
     data = pd.DataFrame(data)
+
+    _validate_input_num_data(data, "data")
 
     if isinstance(target, (str, list, pd.Series, np.ndarray)):
         target_data = []

--- a/src/klib/utils.py
+++ b/src/klib/utils.py
@@ -273,8 +273,9 @@ def _validate_input_sum_larger(limit, desc, *args):
             f"The sum of input values for '{desc}' should be larger/equal to {limit}."
         )
 
+
 def _validate_input_num_data(value: pd.DataFrame, desc):
-    if value.select_dtypes(include=np.number).empty:
+    if value.select_dtypes(include=["number"]).empty:
         raise TypeError(
             f"Input value for '{desc}' should contain at least one numerical column."
         )

--- a/src/klib/utils.py
+++ b/src/klib/utils.py
@@ -272,3 +272,9 @@ def _validate_input_sum_larger(limit, desc, *args):
         raise ValueError(
             f"The sum of input values for '{desc}' should be larger/equal to {limit}."
         )
+
+def _validate_input_num_data(value: pd.DataFrame, desc):
+    if value.select_dtypes(include=np.number).empty:
+        raise TypeError(
+            f"Input value for '{desc}' should contain at least one numerical column."
+        )

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -2,11 +2,13 @@ import unittest
 
 import numpy as np
 import pandas as pd
+
 from klib.utils import _corr_selector
 from klib.utils import _drop_duplicates
 from klib.utils import _missing_vals
 from klib.utils import _validate_input_bool
 from klib.utils import _validate_input_int
+from klib.utils import _validate_input_num_data
 from klib.utils import _validate_input_range
 from klib.utils import _validate_input_smaller
 from klib.utils import _validate_input_sum_larger
@@ -253,3 +255,11 @@ class Test__validate_input(unittest.TestCase):
             _validate_input_sum_larger(-2, "Test Sum >=-2", -3)
         with self.assertRaises(ValueError):
             _validate_input_sum_larger(7, "Test Sum >= 7", 1, 2, 3)
+
+    def test__validate_input_num_data(self):
+        with self.assertRaises(TypeError):
+            _validate_input_num_data(pd.DataFrame({"col1": ["a", "b", "c"]}), None)
+
+        _validate_input_num_data(
+            pd.DataFrame({"col1": [1, 2, 3]}), None
+        )  # No exception


### PR DESCRIPTION
corr_mat naturally returns a matrix based on numerical columns. If the data provided does not have at least one numerical column, corr_mat returns an empty matrix and corr_plot produces an unclear error. I wanted the change this behavior, so I added a simple validation function to check the data if it contains at least one numerical column, so that it can work properly. If it does not, it produces a clear error:

```
TypeError: Input value for 'data' should contain at least one numerical column.
```