### PR TITLE
Delete inappropriate validation in klib.catplot()

### DIFF
--- a/src/klib/describe.py
+++ b/src/klib/describe.py
@@ -68,8 +68,6 @@ def cat_plot(
     # Validate Inputs
     _validate_input_int(top, "top")
     _validate_input_int(bottom, "bottom")
-    _validate_input_range(top, "top", 0, data.shape[1])
-    _validate_input_range(bottom, "bottom", 0, data.shape[1])
     _validate_input_sum_larger(1, "top and bottom", top, bottom)
 
     data = pd.DataFrame(data).copy()


### PR DESCRIPTION
Delete inappropriate Validation in klib.catplot()

top, bottom: is bins number to be visualized for **each column**.

But data.shape[1] = Total column amount.

In the original code, the validation check is to make
```
0 < top, bottom < df.shape[1]
```
This is not logical.

I think you may intend to check boundary for bin number: 
```
for each column
     0 < top, bottom < column.nunique() 
```
 (But the bin number is already adaptive adjusted, see variable top_lim)

So please delete these two lines, or otherwise, eg
when we have a table with 5 column. and we want to set top=6, bop=3.
Error will be raised.