### PR TITLE
Fix Google Colab imcompatibility with corr_interactive_plot 

### DIFF
--- a/src/klib/describe.py
+++ b/src/klib/describe.py
@@ -614,20 +614,22 @@ def corr_interactive_plot(
         ),
     )
 
-    dpi = None
-    for monitor in get_monitors():
-        if monitor.is_primary:
-            if monitor.width_mm is None or monitor.height_mm is None:
-                continue
-            dpi = monitor.width / (monitor.width_mm / 25.4)
-            break
+    try:
+        for monitor in get_monitors():
+            if monitor.is_primary:
+                if monitor.width_mm is None or monitor.height_mm is None:
+                    continue
+                dpi = monitor.width / (monitor.width_mm / 25.4)
+                break
 
-    if dpi is None:
-        monitor = get_monitors()[0]
-        if monitor.width_mm is None or monitor.height_mm is None:
-            dpi = 96  # more or less arbitrary default value
-        else:
-            dpi = monitor.width / (monitor.width_mm / 25.4)
+        if dpi is None:
+            monitor = get_monitors()[0]
+            if monitor.width_mm is None or monitor.height_mm is None:
+                dpi = 96  # more or less arbitrary default value
+            else:
+                dpi = monitor.width / (monitor.width_mm / 25.4)
+    except:
+        dpi = 96
 
     heatmap.update_layout(
         title=f"Feature-correlation ({method})",


### PR DESCRIPTION
| name | about | title | labels | assignees |
| --- | --- | --- | --- | --- |
| Fix | Handle Google Colab error | [FIX] - fix get_monitors() error| fix | @m-marqx | 

When a user calls `corr_interactive_plot` in Google Colab, it will return `ScreenInfoError: No enumerators available` due to the `.get_monitors()` call. In this situation, using a try-except block can handle this error and potentially any other errors related to the screeninfo library.