### PR TITLE
[FIX] Add MultiIndex support

### DIFF
--- a/src/klib/describe.py
+++ b/src/klib/describe.py
@@ -40,7 +40,7 @@ __all__ = [
 ]
 
 
-def cat_plot(  # noqa: C901, PLR915
+def cat_plot(  # noqa: C901, PLR0915
     data: pd.DataFrame,
     figsize: tuple[float, float] = (18, 18),
     top: int = 3,

--- a/src/klib/describe.py
+++ b/src/klib/describe.py
@@ -428,7 +428,7 @@ def corr_plot(
     return ax
 
 
-def corr_interactive_plot(
+def corr_interactive_plot(  # noqa: C901, PLR0913
     data: pd.DataFrame,
     split: Literal["pos", "neg", "high", "low"] | None = None,
     threshold: float = 0.0,

--- a/src/klib/describe.py
+++ b/src/klib/describe.py
@@ -40,7 +40,7 @@ __all__ = [
 ]
 
 
-def cat_plot(  # noqa: C901, PLR0915
+def cat_plot(  # noqa: C901
     data: pd.DataFrame,
     figsize: tuple[float, float] = (18, 18),
     top: int = 3,

--- a/src/klib/describe.py
+++ b/src/klib/describe.py
@@ -591,6 +591,15 @@ def corr_interactive_plot(
 
     vtext = corr.round(2).fillna("") if annot else None
 
+    corr_columns = corr.columns
+    corr_index = corr.index
+
+    if isinstance(corr_columns, pd.MultiIndex):
+        corr_columns = ["-".join(col) for col in corr.columns]
+
+    if isinstance(corr_index, pd.MultiIndex):
+        corr_index = ["-".join(idx) for idx in corr.index]
+
     # Specify kwargs for the heatmap
     kwargs = {
         "colorscale": cmap,
@@ -599,8 +608,8 @@ def corr_interactive_plot(
         "text": vtext,
         "texttemplate": "%{text}",
         "textfont": {"size": 12},
-        "x": corr.columns,
-        "y": corr.index,
+        "x": corr_columns,
+        "y": corr_index,
         "z": corr,
         **kwargs,
     }

--- a/src/klib/describe.py
+++ b/src/klib/describe.py
@@ -40,7 +40,7 @@ __all__ = [
 ]
 
 
-def cat_plot(  # noqa: C901
+def cat_plot(  # noqa: C901, PLR915
     data: pd.DataFrame,
     figsize: tuple[float, float] = (18, 18),
     top: int = 3,
@@ -428,7 +428,7 @@ def corr_plot(
     return ax
 
 
-def corr_interactive_plot(  # noqa: C901, PLR0913
+def corr_interactive_plot(  # noqa: C901
     data: pd.DataFrame,
     split: Literal["pos", "neg", "high", "low"] | None = None,
     threshold: float = 0.0,


### PR DESCRIPTION
One thing I recently noticed is that when a dataframe has MultiIndex columns, the method `corr_interactive_plot` always results in a dataframe with missing labels:

![bug](https://github.com/akanz1/klib/assets/124513922/d6c3635b-f3ab-470f-b071-711fab48aac4)

This error occurs with this method because Plotly struggles with dataframes that have MultiIndex columns. This fix should resolve the missing labels problem by merging the MultiIndex into a list, following the Seaborn format seen in `corr_plot`, to maintain the graph styles.

With this fix:

![fix](https://github.com/akanz1/klib/assets/124513922/c63714b9-1e32-41b0-9c96-1d64947c95d2)

I don't know if this change creates a bug with dataframes that have a MultiIndex index, resulting in an error or a bugged plot, but I can't imagine a real situation where a dataframe would have MultiIndex indexes. However, MultiIndex columns could be possible in very specific situations.


